### PR TITLE
Fixes bug #1 which prevents album covers from displaying for some tile sizes.

### DIFF
--- a/Sonora/Classes/SNRGraphicsHelpers.m
+++ b/Sonora/Classes/SNRGraphicsHelpers.m
@@ -44,7 +44,8 @@ CGColorSpaceRef SNRGetRGBColorSpace(void)
 
 CGContextRef SNRCGContextCreateWithSize(CGSize size) 
 {
-    return CGBitmapContextCreate(NULL, size.width, size.height, 8, 4 * size.width, SNRGetRGBColorSpace(), kCGBitmapByteOrder32Host | kCGImageAlphaPremultipliedLast);
+    size_t widthRounded = (size_t)(size.width + 0.5);
+    return CGBitmapContextCreate(NULL, widthRounded, size.height, 8, 4 * widthRounded, SNRGetRGBColorSpace(), kCGBitmapByteOrder32Host | kCGImageAlphaPremultipliedLast);
 }
 
 #pragma mark - Images


### PR DESCRIPTION
Selecting some tile sizes would cause the rounded value of size.width and size.width*4 not to be multiples of each other raising an exception in CGBitmapContextCreate and preventing the covers from displaying.
