### PR TITLE
Build with the newest version of CocoaPods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-Podfile.lock
 Pods/
 .DS_Store
 *.swp

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,4 +8,4 @@
 	ignore = dirty
 [submodule "External/Sparkle"]
 	path = External/Sparkle
-	url = git://github.com/sonoramac/Sparkle.git
+	url = https://github.com/sparkle-project/Sparkle.git

--- a/Podfile
+++ b/Podfile
@@ -1,9 +1,12 @@
+source 'https://github.com/sonoramac/Podspecs.git'
+source 'https://github.com/cocoapods/specs.git'
+
 platform :osx, '10.7'
 
 pod 'MASShortcut'
 pod 'DBPrefsWindowController'
 pod 'SPMediaKeyTap'
-pod 'INAppStoreWindow', :git => 'git://github.com/sonoramac/INAppStoreWindow.git'
+pod 'INAppStoreWindow'
 pod 'AFNetworking', '1.0RC2'
 pod 'INKeychainAccess'
 pod 'HIDRemoteSDK'

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/cocoapods/specs.git'
 
 platform :osx, '10.7'
 
-pod 'MASShortcut'
+pod 'MASShortcut', '1.3.1'
 pod 'DBPrefsWindowController'
 pod 'SPMediaKeyTap'
 pod 'INAppStoreWindow'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,39 @@
+PODS:
+  - AFNetworking (1.0RC2)
+  - DBPrefsWindowController (1.0.0)
+  - HIDRemoteSDK (1.2)
+  - INAppStoreWindow (1.4)
+  - INKeychainAccess (1.0)
+  - MASShortcut (1.0.0)
+  - OEGridView (1.0.0):
+    - OEGridView/Core (= 1.0.0)
+    - OEGridView/NSColorAdditions (= 1.0.0)
+  - OEGridView/Core (1.0.0)
+  - OEGridView/NSColorAdditions (1.0.0)
+  - SPMediaKeyTap (1.0.0):
+    - SPMediaKeyTap/InvocationGrabbing (= 1.0.0)
+    - SPMediaKeyTap/SPMediaKeyTapBase (= 1.0.0)
+  - SPMediaKeyTap/InvocationGrabbing (1.0.0)
+  - SPMediaKeyTap/SPMediaKeyTapBase (1.0.0)
+
+DEPENDENCIES:
+  - AFNetworking (= 1.0RC2)
+  - DBPrefsWindowController
+  - HIDRemoteSDK
+  - INAppStoreWindow
+  - INKeychainAccess
+  - MASShortcut
+  - OEGridView
+  - SPMediaKeyTap
+
+SPEC CHECKSUMS:
+  AFNetworking: 68f2951fcecba1b881cf75f67201854358f6cf7f
+  DBPrefsWindowController: 49a41d50bdc30ae8171bceaedb25ba5721027b67
+  HIDRemoteSDK: e5dde2a4fdd01ec0193430618dd2a03110e8a27b
+  INAppStoreWindow: 570e4a9768aaac643ef2129d9b018aca2e0157b3
+  INKeychainAccess: 9663e2ab85cc26cc3d4b0f75f83b2d56377397e3
+  MASShortcut: 230d193e57f8732b2dcdb6fa809edb137d53c95d
+  OEGridView: a68e7c99ea668d9ff801caa896a7717fcead6cc6
+  SPMediaKeyTap: 1bf206280cc232eb3c74c51d6315cdfa1976bd14
+
+COCOAPODS: 0.35.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - HIDRemoteSDK (1.2)
   - INAppStoreWindow (1.4)
   - INKeychainAccess (1.0)
-  - MASShortcut (1.0.0)
+  - MASShortcut (1.3.1)
   - OEGridView (1.0.0):
     - OEGridView/Core (= 1.0.0)
     - OEGridView/NSColorAdditions (= 1.0.0)
@@ -22,18 +22,18 @@ DEPENDENCIES:
   - HIDRemoteSDK
   - INAppStoreWindow
   - INKeychainAccess
-  - MASShortcut
+  - MASShortcut (= 1.3.1)
   - OEGridView
   - SPMediaKeyTap
 
 SPEC CHECKSUMS:
   AFNetworking: 68f2951fcecba1b881cf75f67201854358f6cf7f
   DBPrefsWindowController: 49a41d50bdc30ae8171bceaedb25ba5721027b67
-  HIDRemoteSDK: e5dde2a4fdd01ec0193430618dd2a03110e8a27b
+  HIDRemoteSDK: ab4e921cf621484cd88cac6d2ea0b35acb42dc2c
   INAppStoreWindow: 570e4a9768aaac643ef2129d9b018aca2e0157b3
   INKeychainAccess: 9663e2ab85cc26cc3d4b0f75f83b2d56377397e3
-  MASShortcut: 230d193e57f8732b2dcdb6fa809edb137d53c95d
-  OEGridView: a68e7c99ea668d9ff801caa896a7717fcead6cc6
-  SPMediaKeyTap: 1bf206280cc232eb3c74c51d6315cdfa1976bd14
+  MASShortcut: 6f2cb76c6be02151131fb9f08abc5c9dc06c85b2
+  OEGridView: a11e784dd5f6f7a4c30610b590bd71c904792fb3
+  SPMediaKeyTap: 3f0dd6b87ffa128d25a057417e359dcc85207d69
 
 COCOAPODS: 0.35.0

--- a/Sonora.xcodeproj/project.pbxproj
+++ b/Sonora.xcodeproj/project.pbxproj
@@ -817,7 +817,8 @@
 		03F9AD8A1411AAB7006E2873 /* icon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = icon.icns; path = Resources/icon.icns; sourceTree = "<group>"; };
 		03FDF84C15E32D4E009A54B8 /* Sparkle.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Sparkle.xcodeproj; path = External/Sparkle/Sparkle.xcodeproj; sourceTree = "<group>"; };
 		10314D7A429A4257993EE387 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		4695956A88A843CEA204DF02 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = SOURCE_ROOT; };
+		5AC603B2A3EA9AE10D0A0FBC /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		5BBAC83AE0538A5670D11791 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1224,8 +1225,8 @@
 				036417951388CC92003F2A21 /* Products */,
 				03FDF84C15E32D4E009A54B8 /* Sparkle.xcodeproj */,
 				0347F2FD14DCC82600E8E5FC /* SNRHUDKit.xcodeproj */,
-				4695956A88A843CEA204DF02 /* Pods.xcconfig */,
 				03042EA615ED4DB1002C4CA2 /* SFBAudioEngine.xcodeproj */,
+				1AEECB7C08845FCD33FC2CAF /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1737,11 +1738,20 @@
 			children = (
 				03FDF85B15E32D4E009A54B8 /* Sparkle.framework */,
 				03FDF85D15E32D4E009A54B8 /* Sparkle Test App.app */,
-				03FDF85F15E32D4E009A54B8 /* Sparkle Unit Tests.octest */,
+				03FDF85F15E32D4E009A54B8 /* Sparkle Unit Tests.xctest */,
 				03FDF86115E32D4E009A54B8 /* BinaryDelta */,
-				03FDF86315E32D4E009A54B8 /* finish_installation.app */,
+				03FDF86315E32D4E009A54B8 /* Autoupdate.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		1AEECB7C08845FCD33FC2CAF /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				5AC603B2A3EA9AE10D0A0FBC /* Pods.debug.xcconfig */,
+				5BBAC83AE0538A5670D11791 /* Pods.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1868,10 +1878,10 @@
 			remoteRef = 03FDF85C15E32D4E009A54B8 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		03FDF85F15E32D4E009A54B8 /* Sparkle Unit Tests.octest */ = {
+		03FDF85F15E32D4E009A54B8 /* Sparkle Unit Tests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "Sparkle Unit Tests.octest";
+			path = "Sparkle Unit Tests.xctest";
 			remoteRef = 03FDF85E15E32D4E009A54B8 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -1882,10 +1892,10 @@
 			remoteRef = 03FDF86015E32D4E009A54B8 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		03FDF86315E32D4E009A54B8 /* finish_installation.app */ = {
+		03FDF86315E32D4E009A54B8 /* Autoupdate.app */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.application;
-			path = finish_installation.app;
+			path = Autoupdate.app;
 			remoteRef = 03FDF86215E32D4E009A54B8 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -2038,7 +2048,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2387,7 +2397,7 @@
 		};
 		036417B61388CC92003F2A21 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4695956A88A843CEA204DF02 /* Pods.xcconfig */;
+			baseConfigurationReference = 5AC603B2A3EA9AE10D0A0FBC /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ARC_MIGRATION = donothing;
@@ -2421,6 +2431,7 @@
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-all_load",
+					"$(inherited)",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2432,7 +2443,7 @@
 		};
 		036417B71388CC92003F2A21 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4695956A88A843CEA204DF02 /* Pods.xcconfig */;
+			baseConfigurationReference = 5BBAC83AE0538A5670D11791 /* Pods.release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ARC_MIGRATION = donothing;
@@ -2466,6 +2477,7 @@
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-all_load",
+					"$(inherited)",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = NO;

--- a/Sonora/Classes/_SNRAlbum.h
+++ b/Sonora/Classes/_SNRAlbum.h
@@ -19,19 +19,10 @@ extern const struct SNRAlbumRelationships {
 	__unsafe_unretained NSString *thumbnailArtwork;
 } SNRAlbumRelationships;
 
-extern const struct SNRAlbumFetchedProperties {
-} SNRAlbumFetchedProperties;
-
 @class SNRArtist;
 @class SNRArtwork;
 @class SNRSong;
 @class SNRThumbnailArtwork;
-
-
-
-
-
-
 
 @interface SNRAlbumID : NSManagedObjectID {}
 @end
@@ -40,97 +31,59 @@ extern const struct SNRAlbumFetchedProperties {
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
-- (SNRAlbumID*)objectID;
-
-
-
+@property (nonatomic, readonly, strong) SNRAlbumID* objectID;
 
 @property (nonatomic, strong) NSDate* dateModified;
 
-
 //- (BOOL)validateDateModified:(id*)value_ error:(NSError**)error_;
-
-
-
 
 @property (nonatomic, strong) NSNumber* didSearchForArtwork;
 
-
-@property BOOL didSearchForArtworkValue;
+@property (atomic) BOOL didSearchForArtworkValue;
 - (BOOL)didSearchForArtworkValue;
 - (void)setDidSearchForArtworkValue:(BOOL)value_;
 
 //- (BOOL)validateDidSearchForArtwork:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSString* name;
-
 
 //- (BOOL)validateName:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSNumber* popularity;
 
-
-@property double popularityValue;
+@property (atomic) double popularityValue;
 - (double)popularityValue;
 - (void)setPopularityValue:(double)value_;
 
 //- (BOOL)validatePopularity:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSNumber* ranking;
 
-
-@property int32_t rankingValue;
+@property (atomic) int32_t rankingValue;
 - (int32_t)rankingValue;
 - (void)setRankingValue:(int32_t)value_;
 
 //- (BOOL)validateRanking:(id*)value_ error:(NSError**)error_;
 
-
-
-
-
-@property (nonatomic, strong) SNRArtist* artist;
+@property (nonatomic, strong) SNRArtist *artist;
 
 //- (BOOL)validateArtist:(id*)value_ error:(NSError**)error_;
 
-
-
-
-@property (nonatomic, strong) SNRArtwork* artwork;
+@property (nonatomic, strong) SNRArtwork *artwork;
 
 //- (BOOL)validateArtwork:(id*)value_ error:(NSError**)error_;
 
-
-
-
-@property (nonatomic, strong) NSSet* songs;
+@property (nonatomic, strong) NSSet *songs;
 
 - (NSMutableSet*)songsSet;
 
-
-
-
-@property (nonatomic, strong) SNRThumbnailArtwork* thumbnailArtwork;
+@property (nonatomic, strong) SNRThumbnailArtwork *thumbnailArtwork;
 
 //- (BOOL)validateThumbnailArtwork:(id*)value_ error:(NSError**)error_;
 
-
-
-
-
 @end
 
-@interface _SNRAlbum (CoreDataGeneratedAccessors)
-
+@interface _SNRAlbum (SongsCoreDataGeneratedAccessors)
 - (void)addSongs:(NSSet*)value_;
 - (void)removeSongs:(NSSet*)value_;
 - (void)addSongsObject:(SNRSong*)value_;
@@ -140,12 +93,8 @@ extern const struct SNRAlbumFetchedProperties {
 
 @interface _SNRAlbum (CoreDataGeneratedPrimitiveAccessors)
 
-
 - (NSDate*)primitiveDateModified;
 - (void)setPrimitiveDateModified:(NSDate*)value;
-
-
-
 
 - (NSNumber*)primitiveDidSearchForArtwork;
 - (void)setPrimitiveDidSearchForArtwork:(NSNumber*)value;
@@ -153,14 +102,8 @@ extern const struct SNRAlbumFetchedProperties {
 - (BOOL)primitiveDidSearchForArtworkValue;
 - (void)setPrimitiveDidSearchForArtworkValue:(BOOL)value_;
 
-
-
-
 - (NSString*)primitiveName;
 - (void)setPrimitiveName:(NSString*)value;
-
-
-
 
 - (NSNumber*)primitivePopularity;
 - (void)setPrimitivePopularity:(NSNumber*)value;
@@ -168,36 +111,22 @@ extern const struct SNRAlbumFetchedProperties {
 - (double)primitivePopularityValue;
 - (void)setPrimitivePopularityValue:(double)value_;
 
-
-
-
 - (NSNumber*)primitiveRanking;
 - (void)setPrimitiveRanking:(NSNumber*)value;
 
 - (int32_t)primitiveRankingValue;
 - (void)setPrimitiveRankingValue:(int32_t)value_;
 
-
-
-
-
 - (SNRArtist*)primitiveArtist;
 - (void)setPrimitiveArtist:(SNRArtist*)value;
-
-
 
 - (SNRArtwork*)primitiveArtwork;
 - (void)setPrimitiveArtwork:(SNRArtwork*)value;
 
-
-
 - (NSMutableSet*)primitiveSongs;
 - (void)setPrimitiveSongs:(NSMutableSet*)value;
 
-
-
 - (SNRThumbnailArtwork*)primitiveThumbnailArtwork;
 - (void)setPrimitiveThumbnailArtwork:(SNRThumbnailArtwork*)value;
-
 
 @end

--- a/Sonora/Classes/_SNRAlbum.m
+++ b/Sonora/Classes/_SNRAlbum.m
@@ -18,9 +18,6 @@ const struct SNRAlbumRelationships SNRAlbumRelationships = {
 	.thumbnailArtwork = @"thumbnailArtwork",
 };
 
-const struct SNRAlbumFetchedProperties SNRAlbumFetchedProperties = {
-};
-
 @implementation SNRAlbumID
 @end
 
@@ -44,38 +41,31 @@ const struct SNRAlbumFetchedProperties SNRAlbumFetchedProperties = {
 	return (SNRAlbumID*)[super objectID];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
++ (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
-	
+
 	if ([key isEqualToString:@"didSearchForArtworkValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"didSearchForArtwork"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 	if ([key isEqualToString:@"popularityValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"popularity"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 	if ([key isEqualToString:@"rankingValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"ranking"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 
 	return keyPaths;
 }
 
-
-
-
 @dynamic dateModified;
 
-
-
-
-
-
 @dynamic didSearchForArtwork;
-
-
 
 - (BOOL)didSearchForArtworkValue {
 	NSNumber *result = [self didSearchForArtwork];
@@ -95,20 +85,9 @@ const struct SNRAlbumFetchedProperties SNRAlbumFetchedProperties = {
 	[self setPrimitiveDidSearchForArtwork:[NSNumber numberWithBool:value_]];
 }
 
-
-
-
-
 @dynamic name;
 
-
-
-
-
-
 @dynamic popularity;
-
-
 
 - (double)popularityValue {
 	NSNumber *result = [self popularity];
@@ -128,13 +107,7 @@ const struct SNRAlbumFetchedProperties SNRAlbumFetchedProperties = {
 	[self setPrimitivePopularity:[NSNumber numberWithDouble:value_]];
 }
 
-
-
-
-
 @dynamic ranking;
-
-
 
 - (int32_t)rankingValue {
 	NSNumber *result = [self ranking];
@@ -154,38 +127,22 @@ const struct SNRAlbumFetchedProperties SNRAlbumFetchedProperties = {
 	[self setPrimitiveRanking:[NSNumber numberWithInt:value_]];
 }
 
-
-
-
-
 @dynamic artist;
-
-	
 
 @dynamic artwork;
 
-	
-
 @dynamic songs;
 
-	
 - (NSMutableSet*)songsSet {
 	[self willAccessValueForKey:@"songs"];
-  
+
 	NSMutableSet *result = (NSMutableSet*)[self mutableSetValueForKey:@"songs"];
-  
+
 	[self didAccessValueForKey:@"songs"];
 	return result;
 }
-	
 
 @dynamic thumbnailArtwork;
 
-	
-
-
-
-
-
-
 @end
+

--- a/Sonora/Classes/_SNRArtist.h
+++ b/Sonora/Classes/_SNRArtist.h
@@ -14,14 +14,7 @@ extern const struct SNRArtistRelationships {
 	__unsafe_unretained NSString *albums;
 } SNRArtistRelationships;
 
-extern const struct SNRArtistFetchedProperties {
-} SNRArtistFetchedProperties;
-
 @class SNRAlbum;
-
-
-
-
 
 @interface SNRArtistID : NSManagedObjectID {}
 @end
@@ -30,52 +23,31 @@ extern const struct SNRArtistFetchedProperties {
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
-- (SNRArtistID*)objectID;
-
-
-
+@property (nonatomic, readonly, strong) SNRArtistID* objectID;
 
 @property (nonatomic, strong) NSString* name;
 
-
 //- (BOOL)validateName:(id*)value_ error:(NSError**)error_;
-
-
-
 
 @property (nonatomic, strong) NSNumber* ranking;
 
-
-@property int32_t rankingValue;
+@property (atomic) int32_t rankingValue;
 - (int32_t)rankingValue;
 - (void)setRankingValue:(int32_t)value_;
 
 //- (BOOL)validateRanking:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSString* sortingName;
-
 
 //- (BOOL)validateSortingName:(id*)value_ error:(NSError**)error_;
 
-
-
-
-
-@property (nonatomic, strong) NSSet* albums;
+@property (nonatomic, strong) NSSet *albums;
 
 - (NSMutableSet*)albumsSet;
 
-
-
-
-
 @end
 
-@interface _SNRArtist (CoreDataGeneratedAccessors)
-
+@interface _SNRArtist (AlbumsCoreDataGeneratedAccessors)
 - (void)addAlbums:(NSSet*)value_;
 - (void)removeAlbums:(NSSet*)value_;
 - (void)addAlbumsObject:(SNRAlbum*)value_;
@@ -85,12 +57,8 @@ extern const struct SNRArtistFetchedProperties {
 
 @interface _SNRArtist (CoreDataGeneratedPrimitiveAccessors)
 
-
 - (NSString*)primitiveName;
 - (void)setPrimitiveName:(NSString*)value;
-
-
-
 
 - (NSNumber*)primitiveRanking;
 - (void)setPrimitiveRanking:(NSNumber*)value;
@@ -98,18 +66,10 @@ extern const struct SNRArtistFetchedProperties {
 - (int32_t)primitiveRankingValue;
 - (void)setPrimitiveRankingValue:(int32_t)value_;
 
-
-
-
 - (NSString*)primitiveSortingName;
 - (void)setPrimitiveSortingName:(NSString*)value;
 
-
-
-
-
 - (NSMutableSet*)primitiveAlbums;
 - (void)setPrimitiveAlbums:(NSMutableSet*)value;
-
 
 @end

--- a/Sonora/Classes/_SNRArtist.m
+++ b/Sonora/Classes/_SNRArtist.m
@@ -13,9 +13,6 @@ const struct SNRArtistRelationships SNRArtistRelationships = {
 	.albums = @"albums",
 };
 
-const struct SNRArtistFetchedProperties SNRArtistFetchedProperties = {
-};
-
 @implementation SNRArtistID
 @end
 
@@ -39,30 +36,21 @@ const struct SNRArtistFetchedProperties SNRArtistFetchedProperties = {
 	return (SNRArtistID*)[super objectID];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
++ (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
-	
+
 	if ([key isEqualToString:@"rankingValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"ranking"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 
 	return keyPaths;
 }
 
-
-
-
 @dynamic name;
 
-
-
-
-
-
 @dynamic ranking;
-
-
 
 - (int32_t)rankingValue {
 	NSNumber *result = [self ranking];
@@ -82,33 +70,18 @@ const struct SNRArtistFetchedProperties SNRArtistFetchedProperties = {
 	[self setPrimitiveRanking:[NSNumber numberWithInt:value_]];
 }
 
-
-
-
-
 @dynamic sortingName;
-
-
-
-
-
 
 @dynamic albums;
 
-	
 - (NSMutableSet*)albumsSet {
 	[self willAccessValueForKey:@"albums"];
-  
+
 	NSMutableSet *result = (NSMutableSet*)[self mutableSetValueForKey:@"albums"];
-  
+
 	[self didAccessValueForKey:@"albums"];
 	return result;
 }
-	
-
-
-
-
-
 
 @end
+

--- a/Sonora/Classes/_SNRArtwork.h
+++ b/Sonora/Classes/_SNRArtwork.h
@@ -12,12 +12,7 @@ extern const struct SNRArtworkRelationships {
 	__unsafe_unretained NSString *album;
 } SNRArtworkRelationships;
 
-extern const struct SNRArtworkFetchedProperties {
-} SNRArtworkFetchedProperties;
-
 @class SNRAlbum;
-
-
 
 @interface SNRArtworkID : NSManagedObjectID {}
 @end
@@ -26,46 +21,24 @@ extern const struct SNRArtworkFetchedProperties {
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
-- (SNRArtworkID*)objectID;
-
-
-
+@property (nonatomic, readonly, strong) SNRArtworkID* objectID;
 
 @property (nonatomic, strong) NSData* data;
 
-
 //- (BOOL)validateData:(id*)value_ error:(NSError**)error_;
 
-
-
-
-
-@property (nonatomic, strong) SNRAlbum* album;
+@property (nonatomic, strong) SNRAlbum *album;
 
 //- (BOOL)validateAlbum:(id*)value_ error:(NSError**)error_;
-
-
-
-
-
-@end
-
-@interface _SNRArtwork (CoreDataGeneratedAccessors)
 
 @end
 
 @interface _SNRArtwork (CoreDataGeneratedPrimitiveAccessors)
 
-
 - (NSData*)primitiveData;
 - (void)setPrimitiveData:(NSData*)value;
 
-
-
-
-
 - (SNRAlbum*)primitiveAlbum;
 - (void)setPrimitiveAlbum:(SNRAlbum*)value;
-
 
 @end

--- a/Sonora/Classes/_SNRArtwork.m
+++ b/Sonora/Classes/_SNRArtwork.m
@@ -11,9 +11,6 @@ const struct SNRArtworkRelationships SNRArtworkRelationships = {
 	.album = @"album",
 };
 
-const struct SNRArtworkFetchedProperties SNRArtworkFetchedProperties = {
-};
-
 @implementation SNRArtworkID
 @end
 
@@ -37,30 +34,15 @@ const struct SNRArtworkFetchedProperties SNRArtworkFetchedProperties = {
 	return (SNRArtworkID*)[super objectID];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
++ (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
-	
 
 	return keyPaths;
 }
 
-
-
-
 @dynamic data;
-
-
-
-
-
 
 @dynamic album;
 
-	
-
-
-
-
-
-
 @end
+

--- a/Sonora/Classes/_SNRMix.h
+++ b/Sonora/Classes/_SNRMix.h
@@ -18,18 +18,9 @@ extern const struct SNRMixRelationships {
 	__unsafe_unretained NSString *thumbnailArtwork;
 } SNRMixRelationships;
 
-extern const struct SNRMixFetchedProperties {
-} SNRMixFetchedProperties;
-
 @class SNRMixArtwork;
 @class SNRSong;
 @class SNRMixThumbnailArtwork;
-
-
-
-
-
-
 
 @interface SNRMixID : NSManagedObjectID {}
 @end
@@ -38,113 +29,75 @@ extern const struct SNRMixFetchedProperties {
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
-- (SNRMixID*)objectID;
-
-
-
+@property (nonatomic, readonly, strong) SNRMixID* objectID;
 
 @property (nonatomic, strong) NSDate* dateModified;
 
-
 //- (BOOL)validateDateModified:(id*)value_ error:(NSError**)error_;
-
-
-
 
 @property (nonatomic, strong) NSString* iTunesPersistentID;
 
-
 //- (BOOL)validateITunesPersistentID:(id*)value_ error:(NSError**)error_;
-
-
-
 
 @property (nonatomic, strong) NSString* name;
 
-
 //- (BOOL)validateName:(id*)value_ error:(NSError**)error_;
-
-
-
 
 @property (nonatomic, strong) NSNumber* popularity;
 
-
-@property double popularityValue;
+@property (atomic) double popularityValue;
 - (double)popularityValue;
 - (void)setPopularityValue:(double)value_;
 
 //- (BOOL)validatePopularity:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSNumber* ranking;
 
-
-@property int32_t rankingValue;
+@property (atomic) int32_t rankingValue;
 - (int32_t)rankingValue;
 - (void)setRankingValue:(int32_t)value_;
 
 //- (BOOL)validateRanking:(id*)value_ error:(NSError**)error_;
 
-
-
-
-
-@property (nonatomic, strong) SNRMixArtwork* artwork;
+@property (nonatomic, strong) SNRMixArtwork *artwork;
 
 //- (BOOL)validateArtwork:(id*)value_ error:(NSError**)error_;
 
-
-
-
-@property (nonatomic, strong) NSOrderedSet* songs;
+@property (nonatomic, strong) NSOrderedSet *songs;
 
 - (NSMutableOrderedSet*)songsSet;
 
-
-
-
-@property (nonatomic, strong) SNRMixThumbnailArtwork* thumbnailArtwork;
+@property (nonatomic, strong) SNRMixThumbnailArtwork *thumbnailArtwork;
 
 //- (BOOL)validateThumbnailArtwork:(id*)value_ error:(NSError**)error_;
 
-
-
-
-
 @end
 
-@interface _SNRMix (CoreDataGeneratedAccessors)
-
+@interface _SNRMix (SongsCoreDataGeneratedAccessors)
 - (void)addSongs:(NSOrderedSet*)value_;
 - (void)removeSongs:(NSOrderedSet*)value_;
 - (void)addSongsObject:(SNRSong*)value_;
 - (void)removeSongsObject:(SNRSong*)value_;
 
+- (void)insertObject:(SNRSong*)value inSongsAtIndex:(NSUInteger)idx;
+- (void)removeObjectFromSongsAtIndex:(NSUInteger)idx;
+- (void)insertSongs:(NSArray *)value atIndexes:(NSIndexSet *)indexes;
+- (void)removeSongsAtIndexes:(NSIndexSet *)indexes;
+- (void)replaceObjectInSongsAtIndex:(NSUInteger)idx withObject:(SNRSong*)value;
+- (void)replaceSongsAtIndexes:(NSIndexSet *)indexes withSongs:(NSArray *)values;
+
 @end
 
 @interface _SNRMix (CoreDataGeneratedPrimitiveAccessors)
 
-
 - (NSDate*)primitiveDateModified;
 - (void)setPrimitiveDateModified:(NSDate*)value;
-
-
-
 
 - (NSString*)primitiveITunesPersistentID;
 - (void)setPrimitiveITunesPersistentID:(NSString*)value;
 
-
-
-
 - (NSString*)primitiveName;
 - (void)setPrimitiveName:(NSString*)value;
-
-
-
 
 - (NSNumber*)primitivePopularity;
 - (void)setPrimitivePopularity:(NSNumber*)value;
@@ -152,31 +105,19 @@ extern const struct SNRMixFetchedProperties {
 - (double)primitivePopularityValue;
 - (void)setPrimitivePopularityValue:(double)value_;
 
-
-
-
 - (NSNumber*)primitiveRanking;
 - (void)setPrimitiveRanking:(NSNumber*)value;
 
 - (int32_t)primitiveRankingValue;
 - (void)setPrimitiveRankingValue:(int32_t)value_;
 
-
-
-
-
 - (SNRMixArtwork*)primitiveArtwork;
 - (void)setPrimitiveArtwork:(SNRMixArtwork*)value;
-
-
 
 - (NSMutableOrderedSet*)primitiveSongs;
 - (void)setPrimitiveSongs:(NSMutableOrderedSet*)value;
 
-
-
 - (SNRMixThumbnailArtwork*)primitiveThumbnailArtwork;
 - (void)setPrimitiveThumbnailArtwork:(SNRMixThumbnailArtwork*)value;
-
 
 @end

--- a/Sonora/Classes/_SNRMix.m
+++ b/Sonora/Classes/_SNRMix.m
@@ -17,9 +17,6 @@ const struct SNRMixRelationships SNRMixRelationships = {
 	.thumbnailArtwork = @"thumbnailArtwork",
 };
 
-const struct SNRMixFetchedProperties SNRMixFetchedProperties = {
-};
-
 @implementation SNRMixID
 @end
 
@@ -43,48 +40,30 @@ const struct SNRMixFetchedProperties SNRMixFetchedProperties = {
 	return (SNRMixID*)[super objectID];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
++ (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
-	
+
 	if ([key isEqualToString:@"popularityValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"popularity"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 	if ([key isEqualToString:@"rankingValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"ranking"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 
 	return keyPaths;
 }
 
-
-
-
 @dynamic dateModified;
-
-
-
-
-
 
 @dynamic iTunesPersistentID;
 
-
-
-
-
-
 @dynamic name;
 
-
-
-
-
-
 @dynamic popularity;
-
-
 
 - (double)popularityValue {
 	NSNumber *result = [self popularity];
@@ -104,13 +83,7 @@ const struct SNRMixFetchedProperties SNRMixFetchedProperties = {
 	[self setPrimitivePopularity:[NSNumber numberWithDouble:value_]];
 }
 
-
-
-
-
 @dynamic ranking;
-
-
 
 - (int32_t)rankingValue {
 	NSNumber *result = [self ranking];
@@ -130,34 +103,80 @@ const struct SNRMixFetchedProperties SNRMixFetchedProperties = {
 	[self setPrimitiveRanking:[NSNumber numberWithInt:value_]];
 }
 
-
-
-
-
 @dynamic artwork;
-
-	
 
 @dynamic songs;
 
-	
 - (NSMutableOrderedSet*)songsSet {
 	[self willAccessValueForKey:@"songs"];
-  
+
 	NSMutableOrderedSet *result = (NSMutableOrderedSet*)[self mutableOrderedSetValueForKey:@"songs"];
-  
+
 	[self didAccessValueForKey:@"songs"];
 	return result;
 }
-	
 
 @dynamic thumbnailArtwork;
 
-	
-
-
-
-
-
-
 @end
+
+@implementation _SNRMix (SongsCoreDataGeneratedAccessors)
+- (void)addSongs:(NSOrderedSet*)value_ {
+	[self.songsSet unionOrderedSet:value_];
+}
+- (void)removeSongs:(NSOrderedSet*)value_ {
+	[self.songsSet minusOrderedSet:value_];
+}
+- (void)addSongsObject:(SNRSong*)value_ {
+	[self.songsSet addObject:value_];
+}
+- (void)removeSongsObject:(SNRSong*)value_ {
+	[self.songsSet removeObject:value_];
+}
+- (void)insertObject:(SNRSong*)value inSongsAtIndex:(NSUInteger)idx {
+    NSIndexSet* indexes = [NSIndexSet indexSetWithIndex:idx];
+    [self willChange:NSKeyValueChangeInsertion valuesAtIndexes:indexes forKey:@"songs"];
+    NSMutableOrderedSet *tmpOrderedSet = [NSMutableOrderedSet orderedSetWithOrderedSet:[self songs]];
+    [tmpOrderedSet insertObject:value atIndex:idx];
+    [self setPrimitiveValue:tmpOrderedSet forKey:@"songs"];
+    [self didChange:NSKeyValueChangeInsertion valuesAtIndexes:indexes forKey:@"songs"];
+}
+- (void)removeObjectFromSongsAtIndex:(NSUInteger)idx {
+    NSIndexSet* indexes = [NSIndexSet indexSetWithIndex:idx];
+    [self willChange:NSKeyValueChangeRemoval valuesAtIndexes:indexes forKey:@"songs"];
+    NSMutableOrderedSet *tmpOrderedSet = [NSMutableOrderedSet orderedSetWithOrderedSet:[self songs]];
+    [tmpOrderedSet removeObjectAtIndex:idx];
+    [self setPrimitiveValue:tmpOrderedSet forKey:@"songs"];
+    [self didChange:NSKeyValueChangeRemoval valuesAtIndexes:indexes forKey:@"songs"];
+}
+- (void)insertSongs:(NSArray *)value atIndexes:(NSIndexSet *)indexes {
+    [self willChange:NSKeyValueChangeInsertion valuesAtIndexes:indexes forKey:@"songs"];
+    NSMutableOrderedSet *tmpOrderedSet = [NSMutableOrderedSet orderedSetWithOrderedSet:[self songs]];
+    [tmpOrderedSet insertObjects:value atIndexes:indexes];
+    [self setPrimitiveValue:tmpOrderedSet forKey:@"songs"];
+    [self didChange:NSKeyValueChangeInsertion valuesAtIndexes:indexes forKey:@"songs"];
+}
+- (void)removeSongsAtIndexes:(NSIndexSet *)indexes {
+    [self willChange:NSKeyValueChangeRemoval valuesAtIndexes:indexes forKey:@"songs"];
+    NSMutableOrderedSet *tmpOrderedSet = [NSMutableOrderedSet orderedSetWithOrderedSet:[self songs]];
+    [tmpOrderedSet removeObjectsAtIndexes:indexes];
+    [self setPrimitiveValue:tmpOrderedSet forKey:@"songs"];
+    [self didChange:NSKeyValueChangeRemoval valuesAtIndexes:indexes forKey:@"songs"];
+}
+- (void)replaceObjectInSongsAtIndex:(NSUInteger)idx withObject:(SNRSong*)value {
+    NSIndexSet* indexes = [NSIndexSet indexSetWithIndex:idx];
+    [self willChange:NSKeyValueChangeReplacement valuesAtIndexes:indexes forKey:@"songs"];
+    NSMutableOrderedSet *tmpOrderedSet = [NSMutableOrderedSet orderedSetWithOrderedSet:[self songs]];
+    [tmpOrderedSet replaceObjectAtIndex:idx withObject:value];
+    [self setPrimitiveValue:tmpOrderedSet forKey:@"songs"];
+    [self didChange:NSKeyValueChangeReplacement valuesAtIndexes:indexes forKey:@"songs"];
+}
+- (void)replaceSongsAtIndexes:(NSIndexSet *)indexes withSongs:(NSArray *)value {
+    [self willChange:NSKeyValueChangeReplacement valuesAtIndexes:indexes forKey:@"songs"];
+    NSMutableOrderedSet *tmpOrderedSet = [NSMutableOrderedSet orderedSetWithOrderedSet:[self songs]];
+    [tmpOrderedSet replaceObjectsAtIndexes:indexes withObjects:value];
+    [self setPrimitiveValue:tmpOrderedSet forKey:@"songs"];
+    [self didChange:NSKeyValueChangeReplacement valuesAtIndexes:indexes forKey:@"songs"];
+}
+@end
+

--- a/Sonora/Classes/_SNRMixArtwork.h
+++ b/Sonora/Classes/_SNRMixArtwork.h
@@ -13,13 +13,7 @@ extern const struct SNRMixArtworkRelationships {
 	__unsafe_unretained NSString *mix;
 } SNRMixArtworkRelationships;
 
-extern const struct SNRMixArtworkFetchedProperties {
-} SNRMixArtworkFetchedProperties;
-
 @class SNRMix;
-
-
-
 
 @interface SNRMixArtworkID : NSManagedObjectID {}
 @end
@@ -28,54 +22,30 @@ extern const struct SNRMixArtworkFetchedProperties {
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
-- (SNRMixArtworkID*)objectID;
-
-
-
+@property (nonatomic, readonly, strong) SNRMixArtworkID* objectID;
 
 @property (nonatomic, strong) NSData* data;
 
-
 //- (BOOL)validateData:(id*)value_ error:(NSError**)error_;
-
-
-
 
 @property (nonatomic, strong) NSNumber* generated;
 
-
-@property BOOL generatedValue;
+@property (atomic) BOOL generatedValue;
 - (BOOL)generatedValue;
 - (void)setGeneratedValue:(BOOL)value_;
 
 //- (BOOL)validateGenerated:(id*)value_ error:(NSError**)error_;
 
-
-
-
-
-@property (nonatomic, strong) SNRMix* mix;
+@property (nonatomic, strong) SNRMix *mix;
 
 //- (BOOL)validateMix:(id*)value_ error:(NSError**)error_;
-
-
-
-
-
-@end
-
-@interface _SNRMixArtwork (CoreDataGeneratedAccessors)
 
 @end
 
 @interface _SNRMixArtwork (CoreDataGeneratedPrimitiveAccessors)
 
-
 - (NSData*)primitiveData;
 - (void)setPrimitiveData:(NSData*)value;
-
-
-
 
 - (NSNumber*)primitiveGenerated;
 - (void)setPrimitiveGenerated:(NSNumber*)value;
@@ -83,12 +53,7 @@ extern const struct SNRMixArtworkFetchedProperties {
 - (BOOL)primitiveGeneratedValue;
 - (void)setPrimitiveGeneratedValue:(BOOL)value_;
 
-
-
-
-
 - (SNRMix*)primitiveMix;
 - (void)setPrimitiveMix:(SNRMix*)value;
-
 
 @end

--- a/Sonora/Classes/_SNRMixArtwork.m
+++ b/Sonora/Classes/_SNRMixArtwork.m
@@ -12,9 +12,6 @@ const struct SNRMixArtworkRelationships SNRMixArtworkRelationships = {
 	.mix = @"mix",
 };
 
-const struct SNRMixArtworkFetchedProperties SNRMixArtworkFetchedProperties = {
-};
-
 @implementation SNRMixArtworkID
 @end
 
@@ -38,30 +35,21 @@ const struct SNRMixArtworkFetchedProperties SNRMixArtworkFetchedProperties = {
 	return (SNRMixArtworkID*)[super objectID];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
++ (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
-	
+
 	if ([key isEqualToString:@"generatedValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"generated"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 
 	return keyPaths;
 }
 
-
-
-
 @dynamic data;
 
-
-
-
-
-
 @dynamic generated;
-
-
 
 - (BOOL)generatedValue {
 	NSNumber *result = [self generated];
@@ -81,17 +69,7 @@ const struct SNRMixArtworkFetchedProperties SNRMixArtworkFetchedProperties = {
 	[self setPrimitiveGenerated:[NSNumber numberWithBool:value_]];
 }
 
-
-
-
-
 @dynamic mix;
 
-	
-
-
-
-
-
-
 @end
+

--- a/Sonora/Classes/_SNRMixThumbnailArtwork.h
+++ b/Sonora/Classes/_SNRMixThumbnailArtwork.h
@@ -13,13 +13,7 @@ extern const struct SNRMixThumbnailArtworkRelationships {
 	__unsafe_unretained NSString *mix;
 } SNRMixThumbnailArtworkRelationships;
 
-extern const struct SNRMixThumbnailArtworkFetchedProperties {
-} SNRMixThumbnailArtworkFetchedProperties;
-
 @class SNRMix;
-
-
-
 
 @interface SNRMixThumbnailArtworkID : NSManagedObjectID {}
 @end
@@ -28,54 +22,30 @@ extern const struct SNRMixThumbnailArtworkFetchedProperties {
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
-- (SNRMixThumbnailArtworkID*)objectID;
-
-
-
+@property (nonatomic, readonly, strong) SNRMixThumbnailArtworkID* objectID;
 
 @property (nonatomic, strong) NSData* data;
 
-
 //- (BOOL)validateData:(id*)value_ error:(NSError**)error_;
-
-
-
 
 @property (nonatomic, strong) NSNumber* generated;
 
-
-@property BOOL generatedValue;
+@property (atomic) BOOL generatedValue;
 - (BOOL)generatedValue;
 - (void)setGeneratedValue:(BOOL)value_;
 
 //- (BOOL)validateGenerated:(id*)value_ error:(NSError**)error_;
 
-
-
-
-
-@property (nonatomic, strong) SNRMix* mix;
+@property (nonatomic, strong) SNRMix *mix;
 
 //- (BOOL)validateMix:(id*)value_ error:(NSError**)error_;
-
-
-
-
-
-@end
-
-@interface _SNRMixThumbnailArtwork (CoreDataGeneratedAccessors)
 
 @end
 
 @interface _SNRMixThumbnailArtwork (CoreDataGeneratedPrimitiveAccessors)
 
-
 - (NSData*)primitiveData;
 - (void)setPrimitiveData:(NSData*)value;
-
-
-
 
 - (NSNumber*)primitiveGenerated;
 - (void)setPrimitiveGenerated:(NSNumber*)value;
@@ -83,12 +53,7 @@ extern const struct SNRMixThumbnailArtworkFetchedProperties {
 - (BOOL)primitiveGeneratedValue;
 - (void)setPrimitiveGeneratedValue:(BOOL)value_;
 
-
-
-
-
 - (SNRMix*)primitiveMix;
 - (void)setPrimitiveMix:(SNRMix*)value;
-
 
 @end

--- a/Sonora/Classes/_SNRMixThumbnailArtwork.m
+++ b/Sonora/Classes/_SNRMixThumbnailArtwork.m
@@ -12,9 +12,6 @@ const struct SNRMixThumbnailArtworkRelationships SNRMixThumbnailArtworkRelations
 	.mix = @"mix",
 };
 
-const struct SNRMixThumbnailArtworkFetchedProperties SNRMixThumbnailArtworkFetchedProperties = {
-};
-
 @implementation SNRMixThumbnailArtworkID
 @end
 
@@ -38,30 +35,21 @@ const struct SNRMixThumbnailArtworkFetchedProperties SNRMixThumbnailArtworkFetch
 	return (SNRMixThumbnailArtworkID*)[super objectID];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
++ (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
-	
+
 	if ([key isEqualToString:@"generatedValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"generated"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 
 	return keyPaths;
 }
 
-
-
-
 @dynamic data;
 
-
-
-
-
-
 @dynamic generated;
-
-
 
 - (BOOL)generatedValue {
 	NSNumber *result = [self generated];
@@ -81,17 +69,7 @@ const struct SNRMixThumbnailArtworkFetchedProperties SNRMixThumbnailArtworkFetch
 	[self setPrimitiveGenerated:[NSNumber numberWithBool:value_]];
 }
 
-
-
-
-
 @dynamic mix;
 
-	
-
-
-
-
-
-
 @end
+

--- a/Sonora/Classes/_SNRPlayCount.h
+++ b/Sonora/Classes/_SNRPlayCount.h
@@ -12,12 +12,7 @@ extern const struct SNRPlayCountRelationships {
 	__unsafe_unretained NSString *song;
 } SNRPlayCountRelationships;
 
-extern const struct SNRPlayCountFetchedProperties {
-} SNRPlayCountFetchedProperties;
-
 @class SNRSong;
-
-
 
 @interface SNRPlayCountID : NSManagedObjectID {}
 @end
@@ -26,46 +21,24 @@ extern const struct SNRPlayCountFetchedProperties {
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
-- (SNRPlayCountID*)objectID;
-
-
-
+@property (nonatomic, readonly, strong) SNRPlayCountID* objectID;
 
 @property (nonatomic, strong) NSDate* date;
 
-
 //- (BOOL)validateDate:(id*)value_ error:(NSError**)error_;
 
-
-
-
-
-@property (nonatomic, strong) SNRSong* song;
+@property (nonatomic, strong) SNRSong *song;
 
 //- (BOOL)validateSong:(id*)value_ error:(NSError**)error_;
-
-
-
-
-
-@end
-
-@interface _SNRPlayCount (CoreDataGeneratedAccessors)
 
 @end
 
 @interface _SNRPlayCount (CoreDataGeneratedPrimitiveAccessors)
 
-
 - (NSDate*)primitiveDate;
 - (void)setPrimitiveDate:(NSDate*)value;
 
-
-
-
-
 - (SNRSong*)primitiveSong;
 - (void)setPrimitiveSong:(SNRSong*)value;
-
 
 @end

--- a/Sonora/Classes/_SNRPlayCount.m
+++ b/Sonora/Classes/_SNRPlayCount.m
@@ -11,9 +11,6 @@ const struct SNRPlayCountRelationships SNRPlayCountRelationships = {
 	.song = @"song",
 };
 
-const struct SNRPlayCountFetchedProperties SNRPlayCountFetchedProperties = {
-};
-
 @implementation SNRPlayCountID
 @end
 
@@ -37,30 +34,15 @@ const struct SNRPlayCountFetchedProperties SNRPlayCountFetchedProperties = {
 	return (SNRPlayCountID*)[super objectID];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
++ (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
-	
 
 	return keyPaths;
 }
 
-
-
-
 @dynamic date;
-
-
-
-
-
 
 @dynamic song;
 
-	
-
-
-
-
-
-
 @end
+

--- a/Sonora/Classes/_SNRSong.h
+++ b/Sonora/Classes/_SNRSong.h
@@ -31,31 +31,10 @@ extern const struct SNRSongRelationships {
 	__unsafe_unretained NSString *tags;
 } SNRSongRelationships;
 
-extern const struct SNRSongFetchedProperties {
-} SNRSongFetchedProperties;
-
 @class SNRAlbum;
 @class SNRMix;
 @class SNRPlayCount;
 @class SNRTag;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 @interface SNRSongID : NSManagedObjectID {}
 @end
@@ -64,227 +43,147 @@ extern const struct SNRSongFetchedProperties {
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
-- (SNRSongID*)objectID;
-
-
-
+@property (nonatomic, readonly, strong) SNRSongID* objectID;
 
 @property (nonatomic, strong) NSData* bookmark;
 
-
 //- (BOOL)validateBookmark:(id*)value_ error:(NSError**)error_;
-
-
-
 
 @property (nonatomic, strong) NSNumber* compilation;
 
-
-@property BOOL compilationValue;
+@property (atomic) BOOL compilationValue;
 - (BOOL)compilationValue;
 - (void)setCompilationValue:(BOOL)value_;
 
 //- (BOOL)validateCompilation:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSString* composer;
-
 
 //- (BOOL)validateComposer:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSDate* dateAdded;
-
 
 //- (BOOL)validateDateAdded:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSNumber* discNumber;
 
-
-@property int32_t discNumberValue;
+@property (atomic) int32_t discNumberValue;
 - (int32_t)discNumberValue;
 - (void)setDiscNumberValue:(int32_t)value_;
 
 //- (BOOL)validateDiscNumber:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSNumber* discTotal;
 
-
-@property int32_t discTotalValue;
+@property (atomic) int32_t discTotalValue;
 - (int32_t)discTotalValue;
 - (void)setDiscTotalValue:(int32_t)value_;
 
 //- (BOOL)validateDiscTotal:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSNumber* duration;
 
-
-@property int32_t durationValue;
+@property (atomic) int32_t durationValue;
 - (int32_t)durationValue;
 - (void)setDurationValue:(int32_t)value_;
 
 //- (BOOL)validateDuration:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSString* iTunesPersistentID;
-
 
 //- (BOOL)validateITunesPersistentID:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSString* lyrics;
-
 
 //- (BOOL)validateLyrics:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSString* name;
-
 
 //- (BOOL)validateName:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSNumber* popularity;
 
-
-@property double popularityValue;
+@property (atomic) double popularityValue;
 - (double)popularityValue;
 - (void)setPopularityValue:(double)value_;
 
 //- (BOOL)validatePopularity:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSNumber* ranking;
 
-
-@property int32_t rankingValue;
+@property (atomic) int32_t rankingValue;
 - (int32_t)rankingValue;
 - (void)setRankingValue:(int32_t)value_;
 
 //- (BOOL)validateRanking:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSString* rawAlbumArtist;
-
 
 //- (BOOL)validateRawAlbumArtist:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSString* rawArtist;
-
 
 //- (BOOL)validateRawArtist:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSNumber* trackNumber;
 
-
-@property int32_t trackNumberValue;
+@property (atomic) int32_t trackNumberValue;
 - (int32_t)trackNumberValue;
 - (void)setTrackNumberValue:(int32_t)value_;
 
 //- (BOOL)validateTrackNumber:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSNumber* trackTotal;
 
-
-@property int32_t trackTotalValue;
+@property (atomic) int32_t trackTotalValue;
 - (int32_t)trackTotalValue;
 - (void)setTrackTotalValue:(int32_t)value_;
 
 //- (BOOL)validateTrackTotal:(id*)value_ error:(NSError**)error_;
 
-
-
-
 @property (nonatomic, strong) NSNumber* year;
 
-
-@property int32_t yearValue;
+@property (atomic) int32_t yearValue;
 - (int32_t)yearValue;
 - (void)setYearValue:(int32_t)value_;
 
 //- (BOOL)validateYear:(id*)value_ error:(NSError**)error_;
 
-
-
-
-
-@property (nonatomic, strong) SNRAlbum* album;
+@property (nonatomic, strong) SNRAlbum *album;
 
 //- (BOOL)validateAlbum:(id*)value_ error:(NSError**)error_;
 
-
-
-
-@property (nonatomic, strong) NSSet* mixes;
+@property (nonatomic, strong) NSSet *mixes;
 
 - (NSMutableSet*)mixesSet;
 
-
-
-
-@property (nonatomic, strong) NSSet* playCounts;
+@property (nonatomic, strong) NSSet *playCounts;
 
 - (NSMutableSet*)playCountsSet;
 
-
-
-
-@property (nonatomic, strong) NSSet* tags;
+@property (nonatomic, strong) NSSet *tags;
 
 - (NSMutableSet*)tagsSet;
 
-
-
-
-
 @end
 
-@interface _SNRSong (CoreDataGeneratedAccessors)
-
+@interface _SNRSong (MixesCoreDataGeneratedAccessors)
 - (void)addMixes:(NSSet*)value_;
 - (void)removeMixes:(NSSet*)value_;
 - (void)addMixesObject:(SNRMix*)value_;
 - (void)removeMixesObject:(SNRMix*)value_;
 
+@end
+
+@interface _SNRSong (PlayCountsCoreDataGeneratedAccessors)
 - (void)addPlayCounts:(NSSet*)value_;
 - (void)removePlayCounts:(NSSet*)value_;
 - (void)addPlayCountsObject:(SNRPlayCount*)value_;
 - (void)removePlayCountsObject:(SNRPlayCount*)value_;
 
+@end
+
+@interface _SNRSong (TagsCoreDataGeneratedAccessors)
 - (void)addTags:(NSSet*)value_;
 - (void)removeTags:(NSSet*)value_;
 - (void)addTagsObject:(SNRTag*)value_;
@@ -294,12 +193,8 @@ extern const struct SNRSongFetchedProperties {
 
 @interface _SNRSong (CoreDataGeneratedPrimitiveAccessors)
 
-
 - (NSData*)primitiveBookmark;
 - (void)setPrimitiveBookmark:(NSData*)value;
-
-
-
 
 - (NSNumber*)primitiveCompilation;
 - (void)setPrimitiveCompilation:(NSNumber*)value;
@@ -307,20 +202,11 @@ extern const struct SNRSongFetchedProperties {
 - (BOOL)primitiveCompilationValue;
 - (void)setPrimitiveCompilationValue:(BOOL)value_;
 
-
-
-
 - (NSString*)primitiveComposer;
 - (void)setPrimitiveComposer:(NSString*)value;
 
-
-
-
 - (NSDate*)primitiveDateAdded;
 - (void)setPrimitiveDateAdded:(NSDate*)value;
-
-
-
 
 - (NSNumber*)primitiveDiscNumber;
 - (void)setPrimitiveDiscNumber:(NSNumber*)value;
@@ -328,17 +214,11 @@ extern const struct SNRSongFetchedProperties {
 - (int32_t)primitiveDiscNumberValue;
 - (void)setPrimitiveDiscNumberValue:(int32_t)value_;
 
-
-
-
 - (NSNumber*)primitiveDiscTotal;
 - (void)setPrimitiveDiscTotal:(NSNumber*)value;
 
 - (int32_t)primitiveDiscTotalValue;
 - (void)setPrimitiveDiscTotalValue:(int32_t)value_;
-
-
-
 
 - (NSNumber*)primitiveDuration;
 - (void)setPrimitiveDuration:(NSNumber*)value;
@@ -346,26 +226,14 @@ extern const struct SNRSongFetchedProperties {
 - (int32_t)primitiveDurationValue;
 - (void)setPrimitiveDurationValue:(int32_t)value_;
 
-
-
-
 - (NSString*)primitiveITunesPersistentID;
 - (void)setPrimitiveITunesPersistentID:(NSString*)value;
-
-
-
 
 - (NSString*)primitiveLyrics;
 - (void)setPrimitiveLyrics:(NSString*)value;
 
-
-
-
 - (NSString*)primitiveName;
 - (void)setPrimitiveName:(NSString*)value;
-
-
-
 
 - (NSNumber*)primitivePopularity;
 - (void)setPrimitivePopularity:(NSNumber*)value;
@@ -373,29 +241,17 @@ extern const struct SNRSongFetchedProperties {
 - (double)primitivePopularityValue;
 - (void)setPrimitivePopularityValue:(double)value_;
 
-
-
-
 - (NSNumber*)primitiveRanking;
 - (void)setPrimitiveRanking:(NSNumber*)value;
 
 - (int32_t)primitiveRankingValue;
 - (void)setPrimitiveRankingValue:(int32_t)value_;
 
-
-
-
 - (NSString*)primitiveRawAlbumArtist;
 - (void)setPrimitiveRawAlbumArtist:(NSString*)value;
 
-
-
-
 - (NSString*)primitiveRawArtist;
 - (void)setPrimitiveRawArtist:(NSString*)value;
-
-
-
 
 - (NSNumber*)primitiveTrackNumber;
 - (void)setPrimitiveTrackNumber:(NSNumber*)value;
@@ -403,17 +259,11 @@ extern const struct SNRSongFetchedProperties {
 - (int32_t)primitiveTrackNumberValue;
 - (void)setPrimitiveTrackNumberValue:(int32_t)value_;
 
-
-
-
 - (NSNumber*)primitiveTrackTotal;
 - (void)setPrimitiveTrackTotal:(NSNumber*)value;
 
 - (int32_t)primitiveTrackTotalValue;
 - (void)setPrimitiveTrackTotalValue:(int32_t)value_;
-
-
-
 
 - (NSNumber*)primitiveYear;
 - (void)setPrimitiveYear:(NSNumber*)value;
@@ -421,27 +271,16 @@ extern const struct SNRSongFetchedProperties {
 - (int32_t)primitiveYearValue;
 - (void)setPrimitiveYearValue:(int32_t)value_;
 
-
-
-
-
 - (SNRAlbum*)primitiveAlbum;
 - (void)setPrimitiveAlbum:(SNRAlbum*)value;
-
-
 
 - (NSMutableSet*)primitiveMixes;
 - (void)setPrimitiveMixes:(NSMutableSet*)value;
 
-
-
 - (NSMutableSet*)primitivePlayCounts;
 - (void)setPrimitivePlayCounts:(NSMutableSet*)value;
 
-
-
 - (NSMutableSet*)primitiveTags;
 - (void)setPrimitiveTags:(NSMutableSet*)value;
-
 
 @end

--- a/Sonora/Classes/_SNRSong.m
+++ b/Sonora/Classes/_SNRSong.m
@@ -30,9 +30,6 @@ const struct SNRSongRelationships SNRSongRelationships = {
 	.tags = @"tags",
 };
 
-const struct SNRSongFetchedProperties SNRSongFetchedProperties = {
-};
-
 @implementation SNRSongID
 @end
 
@@ -56,62 +53,61 @@ const struct SNRSongFetchedProperties SNRSongFetchedProperties = {
 	return (SNRSongID*)[super objectID];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
++ (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
-	
+
 	if ([key isEqualToString:@"compilationValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"compilation"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 	if ([key isEqualToString:@"discNumberValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"discNumber"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 	if ([key isEqualToString:@"discTotalValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"discTotal"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 	if ([key isEqualToString:@"durationValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"duration"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 	if ([key isEqualToString:@"popularityValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"popularity"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 	if ([key isEqualToString:@"rankingValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"ranking"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 	if ([key isEqualToString:@"trackNumberValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"trackNumber"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 	if ([key isEqualToString:@"trackTotalValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"trackTotal"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 	if ([key isEqualToString:@"yearValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"year"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 
 	return keyPaths;
 }
 
-
-
-
 @dynamic bookmark;
 
-
-
-
-
-
 @dynamic compilation;
-
-
 
 - (BOOL)compilationValue {
 	NSNumber *result = [self compilation];
@@ -131,27 +127,11 @@ const struct SNRSongFetchedProperties SNRSongFetchedProperties = {
 	[self setPrimitiveCompilation:[NSNumber numberWithBool:value_]];
 }
 
-
-
-
-
 @dynamic composer;
-
-
-
-
-
 
 @dynamic dateAdded;
 
-
-
-
-
-
 @dynamic discNumber;
-
-
 
 - (int32_t)discNumberValue {
 	NSNumber *result = [self discNumber];
@@ -171,13 +151,7 @@ const struct SNRSongFetchedProperties SNRSongFetchedProperties = {
 	[self setPrimitiveDiscNumber:[NSNumber numberWithInt:value_]];
 }
 
-
-
-
-
 @dynamic discTotal;
-
-
 
 - (int32_t)discTotalValue {
 	NSNumber *result = [self discTotal];
@@ -197,13 +171,7 @@ const struct SNRSongFetchedProperties SNRSongFetchedProperties = {
 	[self setPrimitiveDiscTotal:[NSNumber numberWithInt:value_]];
 }
 
-
-
-
-
 @dynamic duration;
-
-
 
 - (int32_t)durationValue {
 	NSNumber *result = [self duration];
@@ -223,34 +191,13 @@ const struct SNRSongFetchedProperties SNRSongFetchedProperties = {
 	[self setPrimitiveDuration:[NSNumber numberWithInt:value_]];
 }
 
-
-
-
-
 @dynamic iTunesPersistentID;
-
-
-
-
-
 
 @dynamic lyrics;
 
-
-
-
-
-
 @dynamic name;
 
-
-
-
-
-
 @dynamic popularity;
-
-
 
 - (double)popularityValue {
 	NSNumber *result = [self popularity];
@@ -270,13 +217,7 @@ const struct SNRSongFetchedProperties SNRSongFetchedProperties = {
 	[self setPrimitivePopularity:[NSNumber numberWithDouble:value_]];
 }
 
-
-
-
-
 @dynamic ranking;
-
-
 
 - (int32_t)rankingValue {
 	NSNumber *result = [self ranking];
@@ -296,27 +237,11 @@ const struct SNRSongFetchedProperties SNRSongFetchedProperties = {
 	[self setPrimitiveRanking:[NSNumber numberWithInt:value_]];
 }
 
-
-
-
-
 @dynamic rawAlbumArtist;
-
-
-
-
-
 
 @dynamic rawArtist;
 
-
-
-
-
-
 @dynamic trackNumber;
-
-
 
 - (int32_t)trackNumberValue {
 	NSNumber *result = [self trackNumber];
@@ -336,13 +261,7 @@ const struct SNRSongFetchedProperties SNRSongFetchedProperties = {
 	[self setPrimitiveTrackNumber:[NSNumber numberWithInt:value_]];
 }
 
-
-
-
-
 @dynamic trackTotal;
-
-
 
 - (int32_t)trackTotalValue {
 	NSNumber *result = [self trackTotal];
@@ -362,13 +281,7 @@ const struct SNRSongFetchedProperties SNRSongFetchedProperties = {
 	[self setPrimitiveTrackTotal:[NSNumber numberWithInt:value_]];
 }
 
-
-
-
-
 @dynamic year;
-
-
 
 - (int32_t)yearValue {
 	NSNumber *result = [self year];
@@ -388,56 +301,40 @@ const struct SNRSongFetchedProperties SNRSongFetchedProperties = {
 	[self setPrimitiveYear:[NSNumber numberWithInt:value_]];
 }
 
-
-
-
-
 @dynamic album;
-
-	
 
 @dynamic mixes;
 
-	
 - (NSMutableSet*)mixesSet {
 	[self willAccessValueForKey:@"mixes"];
-  
+
 	NSMutableSet *result = (NSMutableSet*)[self mutableSetValueForKey:@"mixes"];
-  
+
 	[self didAccessValueForKey:@"mixes"];
 	return result;
 }
-	
 
 @dynamic playCounts;
 
-	
 - (NSMutableSet*)playCountsSet {
 	[self willAccessValueForKey:@"playCounts"];
-  
+
 	NSMutableSet *result = (NSMutableSet*)[self mutableSetValueForKey:@"playCounts"];
-  
+
 	[self didAccessValueForKey:@"playCounts"];
 	return result;
 }
-	
 
 @dynamic tags;
 
-	
 - (NSMutableSet*)tagsSet {
 	[self willAccessValueForKey:@"tags"];
-  
+
 	NSMutableSet *result = (NSMutableSet*)[self mutableSetValueForKey:@"tags"];
-  
+
 	[self didAccessValueForKey:@"tags"];
 	return result;
 }
-	
-
-
-
-
-
 
 @end
+

--- a/Sonora/Classes/_SNRTag.h
+++ b/Sonora/Classes/_SNRTag.h
@@ -13,13 +13,7 @@ extern const struct SNRTagRelationships {
 	__unsafe_unretained NSString *songs;
 } SNRTagRelationships;
 
-extern const struct SNRTagFetchedProperties {
-} SNRTagFetchedProperties;
-
 @class SNRSong;
-
-
-
 
 @interface SNRTagID : NSManagedObjectID {}
 @end
@@ -28,44 +22,27 @@ extern const struct SNRTagFetchedProperties {
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
-- (SNRTagID*)objectID;
-
-
-
+@property (nonatomic, readonly, strong) SNRTagID* objectID;
 
 @property (nonatomic, strong) NSString* name;
 
-
 //- (BOOL)validateName:(id*)value_ error:(NSError**)error_;
-
-
-
 
 @property (nonatomic, strong) NSNumber* ranking;
 
-
-@property int32_t rankingValue;
+@property (atomic) int32_t rankingValue;
 - (int32_t)rankingValue;
 - (void)setRankingValue:(int32_t)value_;
 
 //- (BOOL)validateRanking:(id*)value_ error:(NSError**)error_;
 
-
-
-
-
-@property (nonatomic, strong) NSSet* songs;
+@property (nonatomic, strong) NSSet *songs;
 
 - (NSMutableSet*)songsSet;
 
-
-
-
-
 @end
 
-@interface _SNRTag (CoreDataGeneratedAccessors)
-
+@interface _SNRTag (SongsCoreDataGeneratedAccessors)
 - (void)addSongs:(NSSet*)value_;
 - (void)removeSongs:(NSSet*)value_;
 - (void)addSongsObject:(SNRSong*)value_;
@@ -75,12 +52,8 @@ extern const struct SNRTagFetchedProperties {
 
 @interface _SNRTag (CoreDataGeneratedPrimitiveAccessors)
 
-
 - (NSString*)primitiveName;
 - (void)setPrimitiveName:(NSString*)value;
-
-
-
 
 - (NSNumber*)primitiveRanking;
 - (void)setPrimitiveRanking:(NSNumber*)value;
@@ -88,12 +61,7 @@ extern const struct SNRTagFetchedProperties {
 - (int32_t)primitiveRankingValue;
 - (void)setPrimitiveRankingValue:(int32_t)value_;
 
-
-
-
-
 - (NSMutableSet*)primitiveSongs;
 - (void)setPrimitiveSongs:(NSMutableSet*)value;
-
 
 @end

--- a/Sonora/Classes/_SNRTag.m
+++ b/Sonora/Classes/_SNRTag.m
@@ -12,9 +12,6 @@ const struct SNRTagRelationships SNRTagRelationships = {
 	.songs = @"songs",
 };
 
-const struct SNRTagFetchedProperties SNRTagFetchedProperties = {
-};
-
 @implementation SNRTagID
 @end
 
@@ -38,30 +35,21 @@ const struct SNRTagFetchedProperties SNRTagFetchedProperties = {
 	return (SNRTagID*)[super objectID];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
++ (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
-	
+
 	if ([key isEqualToString:@"rankingValue"]) {
 		NSSet *affectingKey = [NSSet setWithObject:@"ranking"];
 		keyPaths = [keyPaths setByAddingObjectsFromSet:affectingKey];
+		return keyPaths;
 	}
 
 	return keyPaths;
 }
 
-
-
-
 @dynamic name;
 
-
-
-
-
-
 @dynamic ranking;
-
-
 
 - (int32_t)rankingValue {
 	NSNumber *result = [self ranking];
@@ -81,26 +69,16 @@ const struct SNRTagFetchedProperties SNRTagFetchedProperties = {
 	[self setPrimitiveRanking:[NSNumber numberWithInt:value_]];
 }
 
-
-
-
-
 @dynamic songs;
 
-	
 - (NSMutableSet*)songsSet {
 	[self willAccessValueForKey:@"songs"];
-  
+
 	NSMutableSet *result = (NSMutableSet*)[self mutableSetValueForKey:@"songs"];
-  
+
 	[self didAccessValueForKey:@"songs"];
 	return result;
 }
-	
-
-
-
-
-
 
 @end
+

--- a/Sonora/Classes/_SNRThumbnailArtwork.h
+++ b/Sonora/Classes/_SNRThumbnailArtwork.h
@@ -12,12 +12,7 @@ extern const struct SNRThumbnailArtworkRelationships {
 	__unsafe_unretained NSString *album;
 } SNRThumbnailArtworkRelationships;
 
-extern const struct SNRThumbnailArtworkFetchedProperties {
-} SNRThumbnailArtworkFetchedProperties;
-
 @class SNRAlbum;
-
-
 
 @interface SNRThumbnailArtworkID : NSManagedObjectID {}
 @end
@@ -26,46 +21,24 @@ extern const struct SNRThumbnailArtworkFetchedProperties {
 + (id)insertInManagedObjectContext:(NSManagedObjectContext*)moc_;
 + (NSString*)entityName;
 + (NSEntityDescription*)entityInManagedObjectContext:(NSManagedObjectContext*)moc_;
-- (SNRThumbnailArtworkID*)objectID;
-
-
-
+@property (nonatomic, readonly, strong) SNRThumbnailArtworkID* objectID;
 
 @property (nonatomic, strong) NSData* data;
 
-
 //- (BOOL)validateData:(id*)value_ error:(NSError**)error_;
 
-
-
-
-
-@property (nonatomic, strong) SNRAlbum* album;
+@property (nonatomic, strong) SNRAlbum *album;
 
 //- (BOOL)validateAlbum:(id*)value_ error:(NSError**)error_;
-
-
-
-
-
-@end
-
-@interface _SNRThumbnailArtwork (CoreDataGeneratedAccessors)
 
 @end
 
 @interface _SNRThumbnailArtwork (CoreDataGeneratedPrimitiveAccessors)
 
-
 - (NSData*)primitiveData;
 - (void)setPrimitiveData:(NSData*)value;
 
-
-
-
-
 - (SNRAlbum*)primitiveAlbum;
 - (void)setPrimitiveAlbum:(SNRAlbum*)value;
-
 
 @end

--- a/Sonora/Classes/_SNRThumbnailArtwork.m
+++ b/Sonora/Classes/_SNRThumbnailArtwork.m
@@ -11,9 +11,6 @@ const struct SNRThumbnailArtworkRelationships SNRThumbnailArtworkRelationships =
 	.album = @"album",
 };
 
-const struct SNRThumbnailArtworkFetchedProperties SNRThumbnailArtworkFetchedProperties = {
-};
-
 @implementation SNRThumbnailArtworkID
 @end
 
@@ -37,30 +34,15 @@ const struct SNRThumbnailArtworkFetchedProperties SNRThumbnailArtworkFetchedProp
 	return (SNRThumbnailArtworkID*)[super objectID];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key {
++ (NSSet*)keyPathsForValuesAffectingValueForKey:(NSString*)key {
 	NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];
-	
 
 	return keyPaths;
 }
 
-
-
-
 @dynamic data;
-
-
-
-
-
 
 @dynamic album;
 
-	
-
-
-
-
-
-
 @end
+


### PR DESCRIPTION
- Update the pods (depends on https://github.com/sonoramac/Podspecs/pull/5) just enough to build sonora. Can probably update some other stuff (like `AFNetworking`)
- Specify podspec sources so new builds don't have to manually clone https://github.com/sonoramac/Podspecs
- Check in `Podfile.lock` no pods won't be updated unless explicitly running `pod update`
- Move submodule to the supported Sparkle branch (I didn't do extensive testing here but it builds successfully)
- It seems like mogenerator had some churn here.

The only other thing I had to do to build sonora was deal with some macro definitions from `SFBAudioEngine`. I'm not sure how to handle that long term.